### PR TITLE
Amélioration des performances de l'export

### DIFF
--- a/ban/auth/models.py
+++ b/ban/auth/models.py
@@ -115,8 +115,8 @@ class Session(db.Model):
                 description: user name
         """
 
-    user = db.ForeignKeyField(User, null=True)
-    client = db.ForeignKeyField(Client, null=True)
+    user = db.CachedForeignKeyField(User, null=True)
+    client = db.CachedForeignKeyField(Client, null=True)
     ip = db.CharField(null=True)  # TODO IPField
     email = db.CharField(null=True)  # TODO EmailField
 

--- a/ban/commands/bal.py
+++ b/ban/commands/bal.py
@@ -20,7 +20,7 @@ def bal(path, limit=0, **kwargs):
     rows = list(helpers.load_csv(path, encoding='utf-8-sig'))
     if limit:
         rows = rows[:limit]
-    helpers.batch(process_rows, rows, total=len(rows))
+    all(helpers.batch(process_rows, rows, total=len(rows)))
 
 
 @helpers.session

--- a/ban/commands/bal.py
+++ b/ban/commands/bal.py
@@ -20,6 +20,7 @@ def bal(path, limit=0, **kwargs):
     rows = list(helpers.load_csv(path, encoding='utf-8-sig'))
     if limit:
         rows = rows[:limit]
+    # Use `all` to force generator evaluation.
     all(helpers.batch(process_rows, rows, total=len(rows)))
 
 

--- a/ban/commands/export.py
+++ b/ban/commands/export.py
@@ -1,9 +1,24 @@
 from pathlib import Path
+import os
 
-from ban.commands import command, reporter
+import peewee
 
-from ban.core import models
+from ban.commands import command
 from ban.core.encoder import dumps
+from ban.core.models import (Group, HouseNumber, Municipality, Position,
+                             PostCode)
+from ban.db import database
+
+from . import helpers
+
+QUERIES = {
+    PostCode: PostCode.select().join(Municipality),
+    Municipality: Municipality.select(),
+    Group: Group.select().join(Municipality),
+    HouseNumber: (HouseNumber.select().join(Group, on=HouseNumber.parent == Group.pk)  # noqa
+                                      .join(Position, peewee.JOIN_LEFT_OUTER, on=Position.housenumber == HouseNumber.pk)  # noqa
+                                      .group_by(HouseNumber.pk)),
+}
 
 
 @command
@@ -12,10 +27,28 @@ def resources(path, **kwargs):
 
     path    path of file where to write resources
     """
-    resources = [models.PostCode, models.Municipality, models.Group,
-                 models.HouseNumber]
-    with Path(path).open(mode='w', encoding='utf-8') as f:
-        for resource in resources:
-            for data in resource.select().serialize({'*': {}}):
-                f.write(dumps(data) + '\n')
-                reporter.notice(resource.__name__, data)
+    resources = [Municipality, PostCode, Group, HouseNumber]
+    for resource in resources:
+        query = QUERIES.get(resource)
+        filename = '{}.ndjson'.format(resource.__name__.lower())
+        with Path(path).joinpath(filename).open(mode='w') as f:
+            print('Exporting to', f.name)
+            query = query.order_by(resource.pk)
+            results = []
+            for result in helpers.batch(process_resource, query,
+                                        chunksize=1000, total=query.count()):
+                results.append(result)
+                if len(results) == 10000:
+                    f.write('\n'.join(results) + '\n')
+                    f.flush()
+                    results = []
+            if results:
+                f.write('\n'.join(results) + '\n')
+
+
+def process_resource(*rows):
+    with database.execution_context():  # Reset connection in current process.
+        results = []
+        for row in rows:
+            results.append(dumps(row.as_export))
+        return results

--- a/ban/commands/helpers.py
+++ b/ban/commands/helpers.py
@@ -69,7 +69,7 @@ def collect_report(func, chunk):
     results = func(*chunk)
     reports = reporter._reports.copy()
     reporter.clear()
-    return len(results), reports
+    return results, reports
 
 
 class ChunkedPool(Pool):
@@ -110,9 +110,10 @@ def batch(func, iterable, chunksize=1000, total=None, progress=True):
     workers = int(config.get('WORKERS', os.cpu_count()))
 
     with ChunkedPool(processes=workers) as pool:
-        for count, reports in pool.imap_unordered(func, iterable, chunksize):
+        for results, reports in pool.imap_unordered(func, iterable, chunksize):
             reporter.merge(reports)
-            bar(step=count)
+            bar(step=len(results))
+            yield from results
         bar.finish()
 
 

--- a/ban/commands/init.py
+++ b/ban/commands/init.py
@@ -35,7 +35,7 @@ def init(*paths, limit=0, **kwargs):
             print('Computing file size')
             total = sum(1 for line in helpers.iter_file(path))
             print('Done computing file size')
-        helpers.batch(process_rows, rows, chunksize=100, total=total)
+        all(helpers.batch(process_rows, rows, chunksize=100, total=total))
 
 
 @helpers.session

--- a/ban/commands/init.py
+++ b/ban/commands/init.py
@@ -35,6 +35,7 @@ def init(*paths, limit=0, **kwargs):
             print('Computing file size')
             total = sum(1 for line in helpers.iter_file(path))
             print('Done computing file size')
+        # Use `all` to force generator evaluation.
         all(helpers.batch(process_rows, rows, chunksize=100, total=total))
 
 

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -166,6 +166,13 @@ class HouseNumber(Model):
         return Municipality.select().join(
            Group, on=Municipality.pk == self.parent.municipality.pk).first()
 
+    @property
+    def as_export(self):
+        """Resources plus relation references without metadata."""
+        mask = {f: {} for f in self.resource_fields}
+        mask['positions'] = {'*': {}}
+        return self.serialize(mask)
+
 
 class Position(Model):
 

--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -63,7 +63,8 @@ class PostCode(NamedModel):
 
     complement = db.CharField(max_length=38, null=True)
     code = db.CharField(index=True, format='\d*', length=5)
-    municipality = db.ForeignKeyField(Municipality, related_name='postcodes')
+    municipality = db.CachedForeignKeyField(Municipality,
+                                            related_name='postcodes')
 
     class Meta:
         indexes = (
@@ -105,7 +106,8 @@ class Group(NamedModel):
     fantoir = db.FantoirField(null=True, unique=True)
     laposte = db.CharField(max_length=8, null=True, unique=True, format='\d*')
     ign = db.CharField(max_length=24, null=True, unique=True)
-    municipality = db.ForeignKeyField(Municipality, related_name='groups')
+    municipality = db.CachedForeignKeyField(Municipality,
+                                            related_name='groups')
 
     @property
     def tmp_fantoir(self):
@@ -139,7 +141,7 @@ class HouseNumber(Model):
                            format=CEA_FORMAT)
     ign = db.CharField(max_length=24, null=True, unique=True)
     ancestors = db.ManyToManyField(Group, related_name='_housenumbers')
-    postcode = db.ForeignKeyField(PostCode, null=True)
+    postcode = db.CachedForeignKeyField(PostCode, null=True)
 
     class Meta:
         indexes = (

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -1,5 +1,5 @@
-import uuid
 from datetime import datetime
+import uuid
 
 import peewee
 from postgis import Point

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -130,6 +130,11 @@ class ResourceModel(db.Model, metaclass=BaseResource):
         return self.serialize({f: {} for f in self.versioned_fields})
 
     @property
+    def as_export(self):
+        """Flat resources plus references. May be filtered or overrided."""
+        return self.serialize({'*': {}})
+
+    @property
     def status(self):
         return 'deleted' if self.deleted_at else 'active'
 

--- a/ban/core/resource.py
+++ b/ban/core/resource.py
@@ -59,7 +59,7 @@ class ResourceModel(db.Model, metaclass=BaseResource):
     exclude_for_version = []
 
     id = db.CharField(max_length=50, unique=True, null=False)
-    deleted_at = db.DateTimeField(null=True)
+    deleted_at = db.DateTimeField(null=True, index=True)
 
     class Meta:
         validator = ResourceValidator

--- a/ban/core/versioning.py
+++ b/ban/core/versioning.py
@@ -47,9 +47,9 @@ class Versioned(db.Model, metaclass=BaseVersioned):
 
     version = db.IntegerField(default=1)
     created_at = db.DateTimeField()
-    created_by = db.ForeignKeyField(Session)
+    created_by = db.CachedForeignKeyField(Session)
     modified_at = db.DateTimeField()
-    modified_by = db.ForeignKeyField(Session)
+    modified_by = db.CachedForeignKeyField(Session)
 
     class Meta:
         validate_backrefs = False
@@ -120,11 +120,7 @@ class Versioned(db.Model, metaclass=BaseVersioned):
     def update_meta(self):
         session = context.get('session')
         if session:  # TODO remove this if, session should be mandatory.
-            try:
-                getattr(self, 'created_by', None)
-            except Session.DoesNotExist:
-                # Field is not nullable, we can't access it when it's not yet
-                # defined.
+            if not self.created_by:
                 self.created_by = session
             self.modified_by = session
         now = utcnow()

--- a/ban/db/cache.py
+++ b/ban/db/cache.py
@@ -2,7 +2,7 @@
 Very simple custom cache.
 functools.lru_cache does not make it, as it only works with hashable types,
 while we need peewee.Expression to be memoized.
-On the other hand, we want to select witch SQL queries will be cached (i.e. not
+On the other hand, we want to select which SQL queries will be cached (i.e. not
 a goal to cache every get on housenumbers or positions), so we cannot just
 cache every SelectQuery.get neither every Model.get.
 """

--- a/ban/db/cache.py
+++ b/ban/db/cache.py
@@ -1,0 +1,42 @@
+"""
+Very simple custom cache.
+functools.lru_cache does not make it, as it only works with hashable types,
+while we need peewee.Expression to be memoized.
+On the other hand, we want to select witch SQL queries will be cached (i.e. not
+a goal to cache every get on housenumbers or positions), so we cannot just
+cache every SelectQuery.get neither every Model.get.
+"""
+
+STORE = {}
+UNSET = ...
+
+
+def key(func):
+    def wrapper(keys, *args, **kwargs):
+        if isinstance(keys, (list, tuple)):
+            keys = '|'.join(map(str, keys))
+        return func(keys, *args, **kwargs)
+    return wrapper
+
+
+@key
+def get(key):
+    return STORE.get(key, UNSET)
+
+
+@key
+def set(key, value):
+    STORE[key] = value
+
+
+@key
+def cache(key, func, *args, **kwargs):
+    cached = get(key)
+    if cached == UNSET:
+        cached = func(*args, **kwargs)
+        set(key, cached)
+    return cached
+
+
+def clear():
+    STORE.clear()

--- a/ban/db/model.py
+++ b/ban/db/model.py
@@ -1,6 +1,7 @@
 import peewee
 
 from .connections import database
+from . import cache
 
 
 class SerializerQueryResultWrapper(peewee.ModelQueryResultWrapper):
@@ -27,9 +28,7 @@ class SelectQuery(peewee.SelectQuery):
 
     def _get_result_wrapper(self):
         wrapper = getattr(self, '_result_wrapper', None)
-        if wrapper:
-            return wrapper
-        return super()._get_result_wrapper()
+        return wrapper or super()._get_result_wrapper()
 
     def __len__(self):
         return self.count()
@@ -53,6 +52,10 @@ class Model(peewee.Model):
     class Meta:
         database = database
         manager = SelectQuery
+
+    def save(self, *args, **kwargs):
+        cache.clear()
+        super().save(*args, **kwargs)
 
     # TODO find a way not to override the peewee.Model select classmethod.
     @classmethod

--- a/ban/tests/test_cache.py
+++ b/ban/tests/test_cache.py
@@ -1,0 +1,64 @@
+from ban.db import cache
+from ban.core import models
+
+from . import factories
+
+
+def test_set_should_add_in_the_cache():
+    cache.set(['1', '2'], 'value')
+    assert cache.STORE['1|2'] == 'value'
+
+
+def test_get_should_retrieve_from_the_cache():
+    cache.set(['1', '2'], 'value')
+    assert cache.get(['1', '2']) == 'value'
+
+
+def test_cache_should_add_to_the_cache_only_if_not_yet_set():
+    cache.cache('key', lambda *args, **kwargs: 'value')
+    assert cache.STORE['key'] == 'value'
+    cache.cache('key', lambda *args, **kwargs: 'othervalue')
+    assert cache.STORE['key'] == 'value'
+
+
+def test_clear_should_clear_the_cache():
+    cache.set('key', 'value')
+    assert cache.STORE
+    cache.clear()
+    assert not cache.STORE
+
+
+def test_group_municipality_should_be_cached(sql_spy):
+    mun = factories.MunicipalityFactory()
+    group1 = factories.GroupFactory(municipality=mun)
+    group2 = factories.GroupFactory(municipality=mun)
+    # Load the models from scratch, otherwise Diff creation has already
+    # populated the "municipality" property
+    group1 = models.Group.first(models.Group.pk == group1.pk)
+    group2 = models.Group.first(models.Group.pk == group1.pk)
+    sql_spy.reset_mock()
+    assert sql_spy.call_count == 0
+    assert group1.municipality == mun
+    assert sql_spy.call_count == 1
+    assert group2.municipality == mun
+    assert sql_spy.call_count == 1
+
+
+def test_saving_should_clear_cache(sql_spy):
+    mun = factories.MunicipalityFactory()
+    group1 = factories.GroupFactory(municipality=mun)
+    group2 = factories.GroupFactory(municipality=mun)
+    # Load the models from scratch, otherwise Diff creation has already
+    # populated the "municipality" property
+    group1 = models.Group.first(models.Group.pk == group1.pk)
+    group2 = models.Group.first(models.Group.pk == group1.pk)
+    sql_spy.reset_mock()
+    assert sql_spy.call_count == 0
+    assert group1.municipality == mun
+    assert sql_spy.call_count == 1
+    mun.version = 2
+    mun.save()
+    sql_spy.reset_mock()
+    assert sql_spy.call_count == 0
+    assert group2.municipality.version == 2
+    assert sql_spy.call_count == 1

--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,7 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     db.database.drop_tables(models)
     db.database.close()
+    db.cache.clear()
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
- split into one file per resource
- cache some foreignkeys (user, session, municipality…)
- add some JOIN
- distribute over processes
- better slice querysets when using helpers.batch
- add Resource.as_export for filtering/customization of exported fields