### PR TITLE
correction construction cia

### DIFF
--- a/ban/core/models.py
+++ b/ban/core/models.py
@@ -115,7 +115,7 @@ class Group(NamedModel):
 
     def get_fantoir(self):
         # Without INSEE code.
-        return self.fantoir[5:] if self.fantoir else self.tmp_fantoir
+        return self.fantoir[5:] if self.fantoir else self.tmp_fantoir[:min(len(self.tmp_fantoir),80)]
 
     @property
     def housenumbers(self):


### PR DESCRIPTION
Correction de la construction d'un cia dans le cas ou le group parent n'a pas de fantoir et un nom de taille supérieure a 100 caractères.
Le CIA ayant une limite a 100 caractères, la construction du cia fait planter l'init.
On utilisera donc les 80 premiers caractères du nom du group parent pour la construction du cia.